### PR TITLE
Proc funcs fix

### DIFF
--- a/src/META-INF/MANIFEST.MF
+++ b/src/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: GUI.Main
+

--- a/src/Triangle/SyntacticAnalyzer/Parser.java
+++ b/src/Triangle/SyntacticAnalyzer/Parser.java
@@ -708,16 +708,16 @@ public class Parser {
     return declarationAST;
   }
 
-  Declaration parsePROC_FUNCS() throws SyntaxError{
+  Declaration parsePROC_FUNCS() throws SyntaxError {
     Declaration declarationAST = null; // in case there's a syntactic error
 
     SourcePosition declarationPos = new SourcePosition();
     start(declarationPos);
-    Declaration dAST1 = null;
-    switch(currentToken.kind) {
+
+    switch (currentToken.kind) {
       case Token.PROC:
       case Token.FUNC:
-        dAST1 = parsePROC_FUNC();
+        declarationAST = parsePROC_FUNC();
         finish(declarationPos);
         break;
       default:
@@ -725,21 +725,23 @@ public class Parser {
                 currentToken.spelling);
         break;
     }
-    if(currentToken.kind == Token.AND){
-       acceptIt();
-       Declaration dAST2 = parsePROC_FUNC();
-       finish(declarationPos);
-       declarationAST = new SequentialDeclaration(dAST1, dAST2, declarationPos);
-       while(currentToken.kind == Token.AND) {
-         acceptIt();
-         start(declarationPos);
-         dAST1 = parsePROC_FUNC();
-         finish(declarationPos);
-         declarationAST = new SequentialDeclaration(declarationAST, dAST1, declarationPos);
-       }
-    }else{
-      declarationAST = dAST1;
-    }
+
+    do {
+      accept(Token.AND);
+      switch(currentToken.kind){
+        case Token.PROC:
+        case Token.FUNC:
+          start(declarationPos);
+          Declaration dAST2 = parsePROC_FUNC();
+          finish(declarationPos);
+          declarationAST = new SequentialDeclaration(declarationAST, dAST2, declarationPos);
+          break;
+        default:
+          syntacticError("\"%\" does not start a proc nor func.",
+                  currentToken.spelling);
+          break;
+      }
+    } while (currentToken.kind == Token.AND);
     return declarationAST;
   }
 

--- a/test/Triangle/SyntacticAnalyzer/testProcFuncRecursive.tri
+++ b/test/Triangle/SyntacticAnalyzer/testProcFuncRecursive.tri
@@ -2,14 +2,12 @@ let
     recursive
         func doble(var i : Integer) : Integer ~
             triplicar(i)/3*2
-        and
-        proc triplicar(var i : Integer) ~
-            i := i + doble(i)
-        end
-        and
-        proc duplicar(var i : Integer) ~
-            i := doble(i)
-        end
+	and
+	func doble2(var i : Integer) : Integer ~
+            triplicar(i)/3*2
+	and
+	func doble3(var i : Integer) : Integer ~
+            triplicar(i)/3*2
     end
 in
     skip

--- a/test/Triangle/SyntacticAnalyzer/testProcFuncRecursiveErrorAnd.tri
+++ b/test/Triangle/SyntacticAnalyzer/testProcFuncRecursiveErrorAnd.tri
@@ -1,0 +1,13 @@
+let
+    recursive
+        func doble(var i : Integer) : Integer ~
+            triplicar(i)/3*2
+	and
+	func doble2(var i : Integer) : Integer ~
+            triplicar(i)/3*2
+	and
+	
+in
+    skip
+end
+! Pruebas para FuncProcs y recursive, error ya que no hay Proc o Func despues del and

--- a/test/Triangle/SyntacticAnalyzer/testProcFuncRecursiveErrorUnProcFunc.tri
+++ b/test/Triangle/SyntacticAnalyzer/testProcFuncRecursiveErrorUnProcFunc.tri
@@ -1,0 +1,9 @@
+let
+    recursive
+        func doble(var i : Integer) : Integer ~
+            triplicar(i)/3*2
+	
+in
+    skip
+end
+! Pruebas para FuncProcs y recursive, error ya que solo hay un proc o func


### PR DESCRIPTION
# Plantilla de cambios

#### Tipo de cambio
- [ ] Característica nueva
- [ ] Mejora
- [x] Arreglo de bug

### Descripción del cambio
    Se modifica el metodo parsePROC_FUNCS() para que obligatoriamente haya más de un proc o func
#### ¿Cómo revisar los cambios?

    Se modifica el archivo de prueba testProcFuncRecursive.tri para la prueba positiva.
    Se adicionan dos archivos de prueba con errores. Uno con el error de que existe solo un proc/func y el otro posee un error con el token "and" ya que no le sigue un proc/func. Los archivos de prueba son testProcRercursiveErrorUnProcFunc.tri y testProcFuncRecursiveErrorAnd.tri respectivamente
### Otros detalles
   null
