### PR TITLE
Fix de chequeo de tipo en llamada futura de param

### DIFF
--- a/src/Triangle/ContextualAnalyzer/Checker.java
+++ b/src/Triangle/ContextualAnalyzer/Checker.java
@@ -585,6 +585,12 @@ public final class Checker implements Visitor {
     FormalParameter fp = (FormalParameter) o;
     TypeDenoter eType = (TypeDenoter) ast.E.visit(this, null);
 
+    //We don't know the type of the future call yet
+    if(eType == null) {
+      idTable.addFutureCallExp(new FutureCallExpression( ((ConstFormalParameter)fp).T, ast.E));
+      return null;
+    }
+
     if (! (fp instanceof ConstFormalParameter))
       reporter.reportError ("const actual parameter not expected here", "",
                             ast.position);

--- a/src/Triangle/ContextualAnalyzer/FutureCallExpression.java
+++ b/src/Triangle/ContextualAnalyzer/FutureCallExpression.java
@@ -7,6 +7,11 @@ public class FutureCallExpression {
     private TypeDenoter typeDenoterToCheck;
     private Expression E;
 
+    /**
+     * Constructor for a call expression with a future declaration
+     * @param typeDenoterToCheck The expected type for the call expression to have
+     * @param e The call expression itself
+     */
     public FutureCallExpression(TypeDenoter typeDenoterToCheck, Expression e) {
         this.typeDenoterToCheck = typeDenoterToCheck;
         E = e;

--- a/test/Triangle/CodeGeneration/actual_param_future_call.tri
+++ b/test/Triangle/CodeGeneration/actual_param_future_call.tri
@@ -1,0 +1,19 @@
+let
+    recursive
+        proc X() ~
+            put(P())
+        end
+
+    and
+
+        func  P() : Char ~ Q()
+
+    and
+
+        func Q() : Char~ 'a'
+    
+   end
+
+in
+    X()
+end

--- a/test/Triangle/CodeGeneration/actual_param_future_call_with_typedef.tri
+++ b/test/Triangle/CodeGeneration/actual_param_future_call_with_typedef.tri
@@ -1,0 +1,15 @@
+let
+    type int ~ Integer;
+
+    recursive
+        proc P()~
+            putint(Q())
+        end
+
+    and
+
+        func Q() : int ~ 1
+    end
+in
+    P()
+end


### PR DESCRIPTION
# Plantilla de cambios

#### Tipo de cambio
- [ ] Característica nueva
- [ ] Mejora
- [X] Arreglo de bug

### Descripción del cambio
    Cuando se realizaba un comando con un parametro siendo un CallExpression futura, al no
    conocer el tipo del mismo se generaba una excepción.
#### ¿Cómo revisar los cambios?
    Crear un programa que realice una llamada con un parámetro de tipo CallExpression,
    (e.g putint(P()) ). Se añaden 2 archivos de prueba con el prefijo actual_param_future_call.
    
### Otros detalles
    [...]
